### PR TITLE
static linking as default in quda

### DIFF
--- a/doall.sh
+++ b/doall.sh
@@ -14,16 +14,16 @@ run step02_qmp.sh
 run step03_qio.sh
 
 # Download, configure, install qla
-run step04_qla.sh
+#run step04_qla.sh
 
 # Download, configure, install qdp
-run step05_qdp.sh
+#run step05_qdp.sh
 
 # Download, configure, install quda
 run step06_quda.sh
 
 # Download, configure, install qopqdp-quda
-run step07_qopqdp.sh
+#run step07_qopqdp.sh
 
 # Download, configure, install qhmc-quda
-run step08_qhmc.sh
+#run step08_qhmc.sh

--- a/env.sh
+++ b/env.sh
@@ -16,8 +16,8 @@ EIGENDIR=${BASEDIR}/quda/eigen/Eigen/
 GITDIR=$(cd "$(dirname "$BASH_SOURCE")"&&pwd)
 
 # use the same compiler for everything
-module load cmake/3.14.5
-module load gcc/8.3.1
+module load cmake
+module load gcc/9.1.0
 
 run(){
 	DONE="$BASEDIR/DONE_$1"

--- a/step06_quda.sh
+++ b/step06_quda.sh
@@ -13,11 +13,16 @@ source "$(cd "$(dirname "$BASH_SOURCE")"&&pwd)/env.sh"
 
 # Download Eigen (for now, this shouldn't be an issue...)
 cd $BASEDIR/quda/eigen/
-wget  http://bitbucket.org/eigen/eigen/get/3.3.7.tar.bz2
-tar -xjf 3.3.7.tar.bz2
+#wget  http://bitbucket.org/eigen/eigen/get/3.3.7.tar.bz2
+wget https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.bz2
+#tar -xjf 3.3.7.tar.bz2
+tar -xjf eigen-3.3.7.tar.bz2
 rm -rf *.tar.bz2
-rm -rf Eigen/eigen*
-mv eigen* Eigen
+#rm -r Eigen
+mkdir Eigen
+mv eigen-3.3.7/Eigen ./Eigen/
+#rm -rf Eigen/eigen*
+#mv eigen* Eigen
 
 # To QUDA!
 
@@ -36,22 +41,26 @@ cd build
 cmake ../quda/ \
 -DEIGEN_INCLUDE_DIR=${EIGENDIR} \
 -DQUDA_TEX=OFF \
--DQUDA_DIRAC_CLOVER=ON \
--DQUDA_DIRAC_DOMAIN_WALL=ON \
+-DQUDA_DIRAC_CLOVER=OFF \
+-DQUDA_DIRAC_DOMAIN_WALL=OFF \
 -DQUDA_DIRAC_NDEG_TWISTED_MASS=OFF \
 -DQUDA_DIRAC_STAGGERED=ON \
 -DQUDA_DIRAC_TWISTED_CLOVER=OFF \
 -DQUDA_DIRAC_TWISTED_MASS=OFF \
--DQUDA_DIRAC_WILSON=ON \
+-DQUDA_DIRAC_WILSON=OFF \
 -DQUDA_DOWNLOAD_EIGEN=OFF \
 -DQUDA_GPU_ARCH=sm_70 \
 -DQUDA_LIMEHOME=${QIODIR} \
--DQUDA_LINK_ASQTAD=ON \
--DQUDA_LINK_HISQ=ON \
+-DQUDA_LINK_ASQTAD=OFF \
+-DQUDA_LINK_HISQ=OFF \
 -DQUDA_MULTIGRID=OFF \
 -DQUDA_QIO=ON \
 -DQUDA_QIOHOME=${QIODIR} \
 -DQUDA_QMP=ON \
--DQUDA_QMPHOME=${QMPDIR}
+-DQUDA_QMPHOME=${QMPDIR} \
+-DQUDA_BUILD_SHAREDLIB=OFF
 
-make -j32
+#make -j32
+#make -j
+make
+#make -j 8


### PR DESCRIPTION
also the url to eigen (and corresponding pathnames) are changed.

(some defaults are changed for ricky's own use and shouldn't go into the master)